### PR TITLE
security: Remove .pypirc from version control and gitignore .pypirc

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -35,3 +35,4 @@ db.sqlite3
 *.swp
 *.DS_Store
 
+.pypirc

--- a/python/.pypirc
+++ b/python/.pypirc
@@ -1,5 +1,0 @@
-[pypi]
-username = __token__
-password = 9df3ff90-f098-4092-a7a4-dd7631783dc7
-
-


### PR DESCRIPTION
# 🔒 Security: Remove PyPI credentials from version control

## Description
Removes `.pypirc` configuration file containing PyPI authentication credentials from version control and adds it to `.gitignore` to prevent future accidental commits.

## Security Impact
- Removes exposed PyPI authentication token from repository
- Prevents future credential exposure by ignoring `.pypirc` files

## Required Actions
- [ ] **URGENT**: Repository administrators should revoke the exposed PyPI token
- [ ] Generate new PyPI token
- [ ] Team members should update their local `.pypirc` with new credentials

## Changes
- Removes `.pypirc` from Git tracking
- Adds `.pypirc` to `.gitignore`

## Additional Notes
This is a security-critical change. 

For team members: Please obtain new PyPI credentials through secure channels. Never commit authentication tokens or sensitive credentials to version control.